### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "mobx": "^5.10.1",
     "mobx-react": "^6.0.3",
     "mobx-react-form": "^2.0.2",
-    "npm": "^6.9.0",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.2.1",
     "postcss-flexbugs-fixes": "4.1.0",


### PR DESCRIPTION

Hello Yoshimori!

It seems like you have npm as one of your (dev-) dependency in twoUp.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
